### PR TITLE
Fix: all units now use configure() method to configure data

### DIFF
--- a/examples.php
+++ b/examples.php
@@ -30,11 +30,16 @@ $converter = new UnitConverter($registry);
 # ========================
 
 $registry->registerUnit(new class extends AbstractUnit {
-  protected $name = "testtt";
-  protected $symbol = "Tst";
-  protected $unitOf = Measure::VOLUME;
-  protected $base = self::class;
-  protected $units = 1;
+  protected function configure () : void
+  {
+    $this
+      ->setName("testtt")
+      ->setSymbol("Tst")
+      ->setUnitOf(Measure::VOLUME)
+      ->setBase(self::class)
+      ->setUnits(1)
+      ;
+  }
 });
 
 # Converting Units

--- a/src/UnitConverter/Unit/AbstractUnit.php
+++ b/src/UnitConverter/Unit/AbstractUnit.php
@@ -52,15 +52,25 @@ abstract class AbstractUnit implements UnitInterface
 
   public function __construct ()
   {
-    $this->units = $this->calculate() ?? $this->units;
+    $this->configure();
+  }
+
+  /**
+   * Configure the current unit of measure.
+   *
+   * @return void
+   */
+  protected function configure () : void
+  {
   }
 
   /**
    * Calculate the amount of required base units to make up 1 unit.
    *
+   * @param mixed $value Unused. Supposed to help determine conversion if using calculate.
    * @return null|float
    */
-  protected function calculate () : ?float
+  protected function calculate ($value) : ?float
   {
     return null;
   }
@@ -98,7 +108,7 @@ abstract class AbstractUnit implements UnitInterface
     return $this->unitOf;
   }
 
-  public function setBase (UnitInterface $base) : UnitInterface
+  public function setBase ($base) : UnitInterface
   {
     $this->base = $base;
     return $this;
@@ -115,8 +125,8 @@ abstract class AbstractUnit implements UnitInterface
     return $this;
   }
 
-  public function getUnits () : float
+  public function getUnits ($value = null) : float
   {
-    return $this->units;
+    return $this->calculate($value) ?? $this->units;
   }
 }

--- a/src/UnitConverter/Unit/Area/Acre.php
+++ b/src/UnitConverter/Unit/Area/Acre.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Acre extends AreaUnit
 {
-  protected $name = "acre";
+  protected function configure () : void
+  {
+    $this
+      ->setName("acre")
 
-  protected $symbol = "ac";
+      ->setSymbol("ac")
 
-  protected $units = 4046.86;
+      ->setUnits(4046.86)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Area/Hectare.php
+++ b/src/UnitConverter/Unit/Area/Hectare.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Hectare extends AreaUnit
 {
-  protected $name = "hectare";
+  protected function configure () : void
+  {
+    $this
+      ->setName("hectare")
 
-  protected $symbol = "ha";
+      ->setSymbol("ha")
 
-  protected $units = 10000;
+      ->setUnits(10000)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Area/SquareCentimeter.php
+++ b/src/UnitConverter/Unit/Area/SquareCentimeter.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class SquareCentimeter extends AreaUnit
 {
-  protected $name = "square centimeter";
+  protected function configure () : void
+  {
+    $this
+      ->setName("square centimeter")
 
-  protected $symbol = "cm2";
+      ->setSymbol("cm2")
 
-  protected $units = 0.0001;
+      ->setUnits(0.0001)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Area/SquareFoot.php
+++ b/src/UnitConverter/Unit/Area/SquareFoot.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class SquareFoot extends AreaUnit
 {
-  protected $name = "square foot";
+  protected function configure () : void
+  {
+    $this
+      ->setName("square foot")
 
-  protected $symbol = "ft2";
+      ->setSymbol("ft2")
 
-  protected $units = 0.092903;
+      ->setUnits(0.092903)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Area/SquareKilometer.php
+++ b/src/UnitConverter/Unit/Area/SquareKilometer.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class SquareKilometer extends AreaUnit
 {
-  protected $name = "square kilometer";
+  protected function configure () : void
+  {
+    $this
+      ->setName("square kilometer")
 
-  protected $symbol = "km2";
+      ->setSymbol("km2")
 
-  protected $units = 1000000;
+      ->setUnits(1000000)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Area/SquareMeter.php
+++ b/src/UnitConverter/Unit/Area/SquareMeter.php
@@ -27,9 +27,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class SquareMeter extends AreaUnit
 {
-  protected $name = "square meter";
+  protected function configure () : void
+  {
+    $this
+      ->setName("square meter")
 
-  protected $symbol = "m2";
+      ->setSymbol("m2")
 
-  protected $units = 1;
+      ->setUnits(1)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Area/SquareMile.php
+++ b/src/UnitConverter/Unit/Area/SquareMile.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class SquareMile extends AreaUnit
 {
-  protected $name = "square mile";
+  protected function configure () : void
+  {
+    $this
+      ->setName("square mile")
 
-  protected $symbol = "mi2";
+      ->setSymbol("mi2")
 
-  protected $units = 2589988.11;
+      ->setUnits(2589988.11)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Area/SquareMillimeter.php
+++ b/src/UnitConverter/Unit/Area/SquareMillimeter.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class SquareMillimeter extends AreaUnit
 {
-  protected $name = "square millimeter";
+  protected function configure () : void
+  {
+    $this
+      ->setName("square millimeter")
 
-  protected $symbol = "mm2";
+      ->setSymbol("mm2")
 
-  protected $units = 0.000001;
+      ->setUnits(0.000001)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/AstronomicalUnit.php
+++ b/src/UnitConverter/Unit/Length/AstronomicalUnit.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class AstronomicalUnit extends LengthUnit
 {
-  protected $name = "astronomical unit";
+  protected function configure () : void
+  {
+    $this
+      ->setName("astronomical unit")
 
-  protected $symbol = "au";
+      ->setSymbol("au")
 
-  protected $units = 149597870700;
+      ->setUnits(149597870700)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Centimeter.php
+++ b/src/UnitConverter/Unit/Length/Centimeter.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Centimeter extends LengthUnit
 {
-  protected $name = "centimeter";
+  protected function configure () : void
+  {
+    $this
+      ->setName("centimeter")
 
-  protected $symbol = "cm";
+      ->setSymbol("cm")
 
-  protected $units = 0.01;
+      ->setUnits(0.01)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Decimeter.php
+++ b/src/UnitConverter/Unit/Length/Decimeter.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Decimeter extends LengthUnit
 {
-  protected $name = "decimeter";
+  protected function configure () : void
+  {
+    $this
+      ->setName("decimeter")
 
-  protected $symbol = "dm";
+      ->setSymbol("dm")
 
-  protected $units = 0.1;
+      ->setUnits(0.1)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Foot.php
+++ b/src/UnitConverter/Unit/Length/Foot.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Foot extends LengthUnit
 {
-  protected $name = "foot";
+  protected function configure () : void
+  {
+    $this
+      ->setName("foot")
 
-  protected $symbol = "ft";
+      ->setSymbol("ft")
 
-  protected $units = 0.3048;
+      ->setUnits(0.3048)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Hand.php
+++ b/src/UnitConverter/Unit/Length/Hand.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Hand extends LengthUnit
 {
-  protected $name = "hand";
+  protected function configure () : void
+  {
+    $this
+      ->setName("hand")
 
-  protected $symbol = "h";
+      ->setSymbol("h")
 
-  protected $units = 0.1016;
+      ->setUnits(0.1016)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Inch.php
+++ b/src/UnitConverter/Unit/Length/Inch.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Inch extends LengthUnit
 {
-  protected $name = "inch";
+  protected function configure () : void
+  {
+    $this
+      ->setName("inch")
 
-  protected $symbol = "in";
+      ->setSymbol("in")
 
-  protected $units = 0.0254;
+      ->setUnits(0.0254)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Kilometer.php
+++ b/src/UnitConverter/Unit/Length/Kilometer.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Kilometer extends LengthUnit
 {
-  protected $name = "kilometer";
+  protected function configure () : void
+  {
+    $this
+      ->setName("kilometer")
 
-  protected $symbol = "km";
+      ->setSymbol("km")
 
-  protected $units = 1000;
+      ->setUnits(1000)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Lightyear.php
+++ b/src/UnitConverter/Unit/Length/Lightyear.php
@@ -26,11 +26,16 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Lightyear extends LengthUnit
 {
-  protected $name = "lightyear";
+  protected function configure () : void
+  {
+    $this
+      ->setName("lightyear")
 
-  protected $symbol = "ly";
+      ->setSymbol("ly")
 
-  # Metric (SI) Units = 9.4607 × 1015 m
-  # – OR – 9.4607 Pm
-  protected $units = 9460730472580800;
+      # Metric (SI) Units = 9.4607 × 1015 m
+      # – OR – 9.4607 Pm
+      ->setUnits(9460730472580800)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Meter.php
+++ b/src/UnitConverter/Unit/Length/Meter.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Meter extends LengthUnit
 {
-  protected $name = "meter";
+  protected function configure () : void
+  {
+    $this
+      ->setName("meter")
 
-  protected $symbol = "m";
+      ->setSymbol("m")
 
-  protected $units = 1;
+      ->setUnits(1)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Micrometer.php
+++ b/src/UnitConverter/Unit/Length/Micrometer.php
@@ -26,9 +26,15 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Micrometer extends LengthUnit
 {
-  protected $name = "micrometer";
+  protected function configure () : void
+  {
+    $this
+      ->setName("micrometer")
 
-  protected $symbol = "µm";
-  
-  protected $units = 0.000001; # 1.0E-6
+      ->setSymbol("µm")
+
+      # 1.0E-6
+      ->setUnits(0.000001)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Mile.php
+++ b/src/UnitConverter/Unit/Length/Mile.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Mile extends LengthUnit
 {
-  protected $name = "mile";
+  protected function configure () : void
+  {
+    $this
+      ->setName("mile")
 
-  protected $symbol = "mi";
+      ->setSymbol("mi")
 
-  protected $units = 1609.344;
+      ->setUnits(1609.344)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Milimeter.php
+++ b/src/UnitConverter/Unit/Length/Milimeter.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Milimeter extends LengthUnit
 {
-  protected $name = "milimeter";
+  protected function configure () : void
+  {
+    $this
+      ->setName("milimeter")
 
-  protected $symbol = "mm";
+      ->setSymbol("mm")
 
-  protected $units = 0.001;
+      ->setUnits(0.001)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Nanometer.php
+++ b/src/UnitConverter/Unit/Length/Nanometer.php
@@ -26,9 +26,15 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Nanometer extends LengthUnit
 {
-  protected $name = "nanometer";
+  protected function configure () : void
+  {
+    $this
+      ->setName("nanometer")
 
-  protected $symbol = "nm";
+      ->setSymbol("nm")
 
-  protected $units = 0.000000001; # 1.0E-9
+      # 1.0E-9
+      ->setUnits(0.000000001)
+      ;  
+  }
 }

--- a/src/UnitConverter/Unit/Length/Parsec.php
+++ b/src/UnitConverter/Unit/Length/Parsec.php
@@ -26,11 +26,17 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Parsec extends LengthUnit
 {
-  protected $name = "parsec";
+  protected function configure () : void
+  {
+    $this
+      ->setName("parsec")
 
-  protected $symbol = "pc";
+      ->setSymbol("pc")
 
-  # Metric (SI) Units = 3.0857×1016 m
-  # – OR – ~31 petametres
-  protected $units = 30856775814913672.789139379577965; # 3.08567758149E+16
+      # Metric (SI) Units = 3.0857×1016 m
+      # – OR – ~31 petametres
+      # 3.08567758149E+16
+      ->setUnits(30856775814913672.789139379577965)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Picometer.php
+++ b/src/UnitConverter/Unit/Length/Picometer.php
@@ -26,9 +26,15 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Picometer extends LengthUnit
 {
-  protected $name = "picometer";
+  protected function configure () : void
+  {
+    $this
+      ->setName("picometer")
 
-  protected $symbol = "pm";
+      ->setSymbol("pm")
 
-  protected $units = 0.000000000001; # 1.0E-12
+      # 1.0E-12
+      ->setUnits(0.000000000001)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Length/Yard.php
+++ b/src/UnitConverter/Unit/Length/Yard.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Yard extends LengthUnit
 {
-  protected $name = "yard";
+  protected function configure () : void
+  {
+    $this
+      ->setName("yard")
 
-  protected $symbol = "yd";
+      ->setSymbol("yd")
 
-  protected $units = 0.9144;
+      ->setUnits(0.9144)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/PlaneAngle/Degree.php
+++ b/src/UnitConverter/Unit/PlaneAngle/Degree.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Degree extends PlaneAngleUnit
 {
-  protected $name = "degree";
+  protected function configure () : void
+  {
+    $this
+      ->setName("degree")
 
-  protected $symbol = "deg";
+      ->setSymbol("deg")
 
-  protected $units = 1;
+      ->setUnits(1)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/PlaneAngle/Radian.php
+++ b/src/UnitConverter/Unit/PlaneAngle/Radian.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class Radian extends PlaneAngleUnit
 {
-  protected $name = "radian";
+  protected function configure () : void
+  {
+    $this
+      ->setName("radian")
 
-  protected $symbol = "rad";
+      ->setSymbol("rad")
 
-  protected $units = 57.2958;
+      ->setUnits(57.2958)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Speed/KilometrePerHour.php
+++ b/src/UnitConverter/Unit/Speed/KilometrePerHour.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class KilometrePerHour extends SpeedUnit
 {
-  protected $name = "kilometre per hour";
+  protected function configure () : void
+  {
+    $this
+      ->setName("kilometre per hour")
 
-  protected $symbol = "kph";
+      ->setSymbol("kph")
 
-  protected $units = 0.277778;
+      ->setUnits(0.277778)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Speed/MetrePerSecond.php
+++ b/src/UnitConverter/Unit/Speed/MetrePerSecond.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class MetrePerSecond extends SpeedUnit
 {
-  protected $name = "metre per second";
+  protected function configure () : void
+  {
+    $this
+      ->setName("metre per second")
 
-  protected $symbol = "mps";
+      ->setSymbol("mps")
 
-  protected $units = 1;
+      ->setUnits(1)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/Speed/MilesPerHour.php
+++ b/src/UnitConverter/Unit/Speed/MilesPerHour.php
@@ -26,9 +26,14 @@ use UnitConverter\Unit\{ AbstractUnit, UnitInterface };
  */
 class MilesPerHour extends SpeedUnit
 {
-  protected $name = "miles per hour";
+  protected function configure () : void
+  {
+    $this
+      ->setName("miles per hour")
 
-  protected $symbol = "mph";
+      ->setSymbol("mph")
 
-  protected $units = 0.44704;
+      ->setUnits(0.44704)
+      ;
+  }
 }

--- a/src/UnitConverter/Unit/UnitInterface.php
+++ b/src/UnitConverter/Unit/UnitInterface.php
@@ -70,7 +70,7 @@ interface UnitInterface
    *
    * @return UnitInterface
    */
-  public function setBase (UnitInterface $base) : UnitInterface;
+  public function setBase ($base) : UnitInterface;
 
   /**
    * Returns the unit class that this unit is based off of.
@@ -89,7 +89,8 @@ interface UnitInterface
   /**
    * Returns the amount of base units required to make up 1 of the unit.
    *
+   * @param mixed $value Unused. Supposed to help determine conversion if using calculate.
    * @return float
    */
-  public function getUnits () : float;
+  public function getUnits ($value = null) : float;
 }

--- a/tests/unit/UnitConverter/Registry/UnitRegistry.spec.php
+++ b/tests/unit/UnitConverter/Registry/UnitRegistry.spec.php
@@ -161,11 +161,16 @@ class UnitRegistrySpec extends TestCase
     $this->assertFalse($this->registry->isUnitRegistered("mm"));
 
     $this->registry->registerUnit(new class extends AbstractUnit {
-      protected $name = "saiyanPower";
-      protected $symbol = "sP";
-      protected $unitOf = "energy";
-      protected $base = self::class;
-      protected $units = 9001;
+      protected function configure () : void
+      {
+        $this
+          ->setName("saiyanPower")
+          ->setSymbol("sP")
+          ->setUnitOf("energy")
+          ->setBase(self::class)
+          ->setUnits(9001)
+          ;
+      }
     });
     $this->registry->registerUnits([new Meter, new Milimeter]);
 
@@ -181,12 +186,17 @@ class UnitRegistrySpec extends TestCase
   public function assertRegisteringUnitsUnderUnknownMeasurementsThrowsOutOfBoundsException ()
   {
     $this->expectException("UnitConverter\\Exception\\UnknownMeasurementTypeException");
-    $this->registry->registerUnit(new class extends AbstractUnit {
-      protected $name = "testtt";
-      protected $symbol = "Tst";
-      protected $unitOf = "NO EXIST LOL";
-      protected $base = self::class;
-      protected $units = 1;
+      $this->registry->registerUnit(new class extends AbstractUnit {
+      protected function configure () : void
+      {
+        $this
+          ->setName("testtt")
+          ->setSymbol("Tst")
+          ->setUnitOf("NO EXIST LOL")
+          ->setBase(self::class)
+          ->setUnits(1)
+          ;
+      }
     });
   }
 


### PR DESCRIPTION
This will help solve the issue with #18 by allowing the use of `AbstractUnit::calculate()` for evaluating one-way conversions (e.g., `°C <-> °F`)