### PR TITLE
Fix: add missing self conversions for temperature units

### DIFF
--- a/src/UnitConverter/Unit/Temperature/Celsius.php
+++ b/src/UnitConverter/Unit/Temperature/Celsius.php
@@ -44,9 +44,17 @@ class Celsius extends TemperatureUnit
       case 'f': # °F = (°C × (9 ÷ 5)) + 32
         return ($val * (9 / 5)) + 32;
         break;
-      default: # °K = °C + 273.15
+
+      case 'k': # °K = °C + 273.15
         return ($val + 273.15);
         break;
+
+      case 'c': # °C = °C
+        return $val;
+        break;
+        
+      default:
+        throw new \Exception("Unknown conversion formula for {$to->getSymbol()}");
     }
   }
 }

--- a/src/UnitConverter/Unit/Temperature/Fahrenheit.php
+++ b/src/UnitConverter/Unit/Temperature/Fahrenheit.php
@@ -45,9 +45,16 @@ class Fahrenheit extends TemperatureUnit
         return ($val - 32) * (5 / 9);
         break;
 
-      default: # °K = (°F + 459.67) × (5 ÷ 9)
+      case 'k': # °K = (°F + 459.67) × (5 ÷ 9)
         return (($val + 459.67) * 5 / 9);
         break;
+
+      case 'f': # °F = °F
+        return $val;
+        break;
+
+      default:
+        throw new \Exception("Unknown conversion formula for {$to->getSymbol()}");
     }
   }
 }


### PR DESCRIPTION
Temperature units need many different formulae to convert amongst themselves. The only way around this as far as I can tell would be to convert all °C / °F temperature units into their Kelvin counterparts, then convert the result down into the targeted unit (°F / °C respectively).

For now, a switch has been implemented in each units' `::calculate()` method, that will handle the conversion itself.

_Temperature units are nasty..._ 😑