### PR TITLE
Feat: add explicit calculator classes to handle all math related operations

### DIFF
--- a/src/UnitConverter/Calculator/AbstractCalculator.php
+++ b/src/UnitConverter/Calculator/AbstractCalculator.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This file is part of the jordanbrauer/unit-converter PHP package.
+ *
+ * @copyright 2017 Jordan Brauer <jbrauer.inc@gmail.com>
+ * @license MIT
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace UnitConverter\Calculator;
+
+/**
+ * Internal math helper class for floating point decimal
+ * percision
+ *
+ * @version 1.0.0
+ * @since 0.4.1
+ * @author Jordan Brauer <jbrauer.inc@gmail.com>
+ */
+abstract class AbstractCalculator implements CalculatorInterface
+{
+  /**
+   * @var int $precision The number of decimal places that will calculated
+   */
+  protected $precision;
+
+  /**
+   * Public constructor for the unit converter calculator.
+   *
+   * @param int $precision The number of decimal places that will be calculated
+   */
+  public function __construct (int $precision = 2)
+  {
+    $this->setPrecision($precision);
+  }
+
+  public function setPrecision (int $precision): CalculatorInterface
+  {
+    $this->precision = $precision;
+    return $this;
+  }
+
+  public function getPrecision (): int
+  {
+    return $this->precision;
+  }
+
+  abstract public function add ($leftOperand, $rightOperand);
+
+  abstract public function sub ($leftOperand, $rightOperand);
+
+  abstract public function mul ($leftOperand, $rightOperand);
+
+  abstract public function div ($dividend, $divisor);
+
+  abstract public function mod ($dividend, $modulus);
+
+  abstract public function pow ($base, $exponent);
+
+
+  /**
+   * Syntacital sugar wrapper method for sub
+   */
+  public function subtract (...$params)
+  {
+    return $this->sub(...$params);
+  }
+
+  /**
+   * Syntacital sugar wrapper method for mul
+   */
+  public function multiply (...$params)
+  {
+    return $this->mul(...$params);
+  }
+
+  /**
+   * Syntacital sugar wrapper method for div
+   */
+  public function divide (...$params)
+  {
+    return $this->div(...$params);
+  }
+
+  /**
+   * Syntacital sugar wrapper method for mod
+   */
+  public function modulus (...$params)
+  {
+    return $this->mod(...$params);
+  }
+
+  /**
+   * Syntacital sugar wrapper method for pow
+   */
+  public function power (...$params)
+  {
+    return $this->pow(...$params);
+  }
+}

--- a/src/UnitConverter/Calculator/BinaryCalculator.php
+++ b/src/UnitConverter/Calculator/BinaryCalculator.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of the jordanbrauer/unit-converter PHP package.
+ *
+ * @copyright 2017 Jordan Brauer <jbrauer.inc@gmail.com>
+ * @license MIT
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace UnitConverter\Calculator;
+
+/**
+ * Internal math helper class for floating point decimal
+ * percision
+ *
+ * @version 1.0.0
+ * @since 0.4.1
+ * @author Jordan Brauer <jbrauer.inc@gmail.com>
+ */
+class BinaryCalculator extends AbstractCalculator
+{
+  public function setPrecision(int $precision): CalculatorInterface
+  {
+    parent::setPrecision($precision);
+    bcscale($precision);
+    return $this;
+  }
+
+  public function add ($leftOperand, $rightOperand)
+  {
+    return bcadd($leftOperand, $rightOperand);
+  }
+
+  public function sub ($leftOperand, $rightOperand)
+  {
+    return bcsub($leftOperand, $rightOperand);
+  }
+
+  public function mul ($leftOperand, $rightOperand)
+  {
+    return bcmul($leftOperand, $rightOperand);
+  }
+
+  public function div ($dividend, $divisor)
+  {
+    return bcdiv($dividend, $divisor);
+  }
+
+  public function mod ($dividend, $modulus)
+  {
+    return bcmod($dividend, $modulus);
+  }
+
+  public function pow ($base, $exponent)
+  {
+    return bcpow($base, $exponent);
+  }
+}

--- a/src/UnitConverter/Calculator/CalculatorInterface.php
+++ b/src/UnitConverter/Calculator/CalculatorInterface.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This file is part of the jordanbrauer/unit-converter PHP package.
+ *
+ * @copyright 2017 Jordan Brauer <jbrauer.inc@gmail.com>
+ * @license MIT
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace UnitConverter\Calculator;
+
+/**
+ * Internal math helper class for floating point decimal
+ * percision
+ *
+ * @version 1.0.0
+ * @since 0.4.1
+ * @author Jordan Brauer <jbrauer.inc@gmail.com>
+ */
+interface CalculatorInterface
+{
+  /**
+   * Set default decimal precision for all math functions
+   *
+   * @param int $precision The amount of decimal places that will be returned
+   * @return Calculator
+   */
+  public function setPrecision (int $precision): CalculatorInterface;
+
+  /**
+   * Returns the current decimal precision for the calculator
+   *
+   * @return int
+   */
+  public function getPrecision (): int;
+
+  /**
+   * Add two arbitrary precision numbers
+   *
+   * @param int|float|string $leftOperand The number left of the operator
+   * @param int|float|string $rightOperand The number right of the operator
+   * @return int|float|string
+   */
+  public function add ($leftOperand, $rightOperand);
+
+  /**
+   * Subtract one arbitrary precision number from another
+   *
+   * @param int|float|string $leftOperand The number left of the operator
+   * @param int|float|string $rightOperand The number right of the operator
+   * @return int|float|string
+   */
+  public function sub ($leftOperand, $rightOperand);
+
+  /**
+   * Multiply two arbitrary precision numbers
+   *
+   * @param int|float|string $leftOperand The number left of the operator
+   * @param int|float|string $rightOperand The number right of the operator
+   * @return int|float|string
+   */
+  public function mul ($leftOperand, $rightOperand);
+
+  /**
+   * Divide two arbitrary precision numbers
+   *
+   * @param int|float|string $dividend The number beind divided
+   * @param int|float|string $divisor The number that is doing the dividing
+   * @return int|float|string
+   */
+  public function div ($dividend, $divisor);
+
+  /**
+   * Get modulus of an arbitrary precision number
+   *
+   * @param int|float|string $dividend The dividend as a string
+   * @param int|float|string $modulus The modulus as a string
+   * @return int|float|string
+   */
+  public function mod ($dividend, $modulus);
+
+  /**
+   * Raise an arbitrary precision number to another
+   *
+   * @param int|float|string $base The base, as a string.
+   * @param int|float|string $exponent The exponent, as a string. If the exponent is non-integral, it is truncated. The valid range of the exponent is platform specific, but is at least -2147483648 to 2147483647.
+   * @return int|float|string
+   */
+  public function pow ($base, $exponent);
+}

--- a/src/UnitConverter/Calculator/SimpleCalculator.php
+++ b/src/UnitConverter/Calculator/SimpleCalculator.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of the jordanbrauer/unit-converter PHP package.
+ *
+ * @copyright 2017 Jordan Brauer <jbrauer.inc@gmail.com>
+ * @license MIT
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace UnitConverter\Calculator;
+
+/**
+ * Internal math helper class for floating point decimal
+ * percision
+ *
+ * @version 1.0.0
+ * @since 0.4.1
+ * @author Jordan Brauer <jbrauer.inc@gmail.com>
+ */
+class SimpleCalculator extends AbstractCalculator
+{
+  /**
+   * @var int $roundingMode The mode in which rounding occurs. Use one of the PHP_ROUND_HALF_* constants.
+   */
+  protected $roundingMode;
+
+  public function __construct (int $precision = 2, int $roundingMode = PHP_ROUND_HALF_UP)
+  {
+    parent::__construct($precision);
+    $this->setRoundingMode($roundingMode);
+  }
+
+  /**
+   * Use one of the PHP_ROUND_HALF_* constants to specify
+   * the mode in which rounding occurs.
+   *
+   * @link https://secure.php.net/manual/en/function.round.php
+   *
+   * @param int $mode The mode in which rounding occurs
+   * @return CalculatorInterface
+   */
+  public function setRoundingMode (int $roundingMode = PHP_ROUND_HALF_UP): CalculatorInterface
+  {
+    $this->roundingMode = $roundingMode;
+    return $this;
+  }
+
+  /**
+   * Return the current rounding mode
+   *
+   * @return int
+   */
+  public function getRoundingMode (): int
+  {
+    return $this->roundingMode;
+  }
+
+  /**
+   * Return the result of a rounded float
+   *
+   * @param int|float $value The value to round
+   * @return float
+   */
+  public function round ($value): float
+  {
+    return round(
+      $value,
+      $this->getPrecision(),
+      $this->getRoundingMode()
+    );
+  }
+
+  public function add ($leftOperand, $rightOperand)
+  {
+    return $this->round(($leftOperand + $rightOperand));
+  }
+
+  public function sub ($leftOperand, $rightOperand)
+  {
+    return $this->round(($leftOperand - $rightOperand));
+  }
+
+  public function mul ($leftOperand, $rightOperand)
+  {
+    return $this->round(($leftOperand * $rightOperand));
+  }
+
+  public function div ($dividend, $divisor)
+  {
+    return $this->round(($dividend / $divisor));
+  }
+
+  public function mod ($dividend, $modulus)
+  {
+    return $this->round(($dividend % $modulus));
+  }
+
+  public function pow ($base, $exponent)
+  {
+    return $this->round(pow($base, $exponent));
+  }
+}

--- a/src/UnitConverter/UnitConverter.php
+++ b/src/UnitConverter/UnitConverter.php
@@ -15,7 +15,6 @@ declare(strict_types = 1);
 namespace UnitConverter;
 
 use UnitConverter\Exception\MissingUnitRegistryException;
-use UnitConverter\Measure;
 use UnitConverter\Unit\UnitInterface;
 use UnitConverter\Registry\UnitRegistryInterface;
 
@@ -133,7 +132,6 @@ class UnitConverter implements UnitConverterInterface
   public function to (string $unit)
   {
     $this->to = $this->loadUnit($unit);
-
     return $this->calculate($this->convert, $this->from, $this->to);
   }
 }

--- a/tests/unit/UnitConverter/Calculator/BinaryCalculator.spec.php
+++ b/tests/unit/UnitConverter/Calculator/BinaryCalculator.spec.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This file is part of the jordanbrauer/unit-converter PHP package.
+ *
+ * @copyright 2017 Jordan Brauer <jbrauer.inc@gmail.com>
+ * @license MIT
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace UnitConverter\Tests\Unit\Calculator;
+
+use PHPUnit\Framework\TestCase;
+use UnitConverter\Calculator\BinaryCalculator;
+
+
+/**
+ * @coversDefaultClass UnitConverter\BinaryCalculator
+ */
+class BinaryCalculatorSpec extends TestCase
+{
+  protected function setUp()
+  {
+    $this->calculator = new BinaryCalculator;
+  }
+
+  protected function tearDown()
+  {
+    unset($this->calculator);
+  }
+
+  /**
+   * @test
+   * @covers ::add
+   */
+  public function assertAddingTwoNumbersWorksAsExpected ()
+  {
+    $expected = 5;
+    $actual = $this->calculator->add("2.5", "2.5");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("string", $actual);
+  }
+
+  /**
+   * @test
+   * @covers ::sub
+   */
+  public function assertSubtractingTwoNumbersWorksAsExpected ()
+  {
+    $expected = 2.5;
+    $actual = $this->calculator->sub("5", "2.5");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("string", $actual);
+  }
+
+  /**
+   * @test
+   * @covers ::mul
+   */
+  public function assertMultiplyMethodProperlyMultipliesTwoNumbers ()
+  {
+    $expected = 4;
+    $actual = $this->calculator->mul("2", "2");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("string", $actual);
+  }
+
+  /**
+   * @test
+   * @covers ::div
+   */
+  public function assertDivideMethodProperlyDividesTwoNumbers ()
+  {
+    $expected = 2;
+    $actual = $this->calculator->div("4", "2");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("string", $actual);
+  }
+
+  /**
+   * @test
+   * @covers ::mod
+   */
+  public function assertModulusMethodProperlyReturnsTheRemainderOfDivision ()
+  {
+    $expected = 1;
+    $actual = $this->calculator->mod("5", "2");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("string", $actual);
+  }
+
+  /**
+   * @test
+   * @covers ::pow
+   */
+  public function assertPowerMethodRaisesBaseNumberToPowerExponent ()
+  {
+    $expected = 100;
+    $actual = $this->calculator->pow("10", "2");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("string", $actual);
+  }
+}

--- a/tests/unit/UnitConverter/Calculator/SimpleCalculator.spec.php
+++ b/tests/unit/UnitConverter/Calculator/SimpleCalculator.spec.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This file is part of the jordanbrauer/unit-converter PHP package.
+ *
+ * @copyright 2017 Jordan Brauer <jbrauer.inc@gmail.com>
+ * @license MIT
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace UnitConverter\Tests\Unit\Calculator;
+
+use PHPUnit\Framework\TestCase;
+use UnitConverter\Calculator\SimpleCalculator;
+
+
+/**
+ * @coversDefaultClass UnitConverter\SimpleCalculator
+ */
+class SimpleCalculatorSpec extends TestCase
+{
+  protected function setUp()
+  {
+    $this->calculator = new SimpleCalculator;
+  }
+
+  protected function tearDown()
+  {
+    unset($this->calculator);
+  }
+
+  /**
+   * @test
+   * @covers ::add
+   */
+  public function assertAddingTwoNumbersWorksAsExpected ()
+  {
+    $expected = 5;
+    $actual = $this->calculator->add("2.5", "2.5");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("float", $actual);
+  }
+
+  /**
+   * @test
+   * @covers ::sub
+   */
+  public function assertSubtractingTwoNumbersWorksAsExpected ()
+  {
+    $expected = 2.5;
+    $actual = $this->calculator->sub("5", "2.5");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("float", $actual);
+  }
+
+  /**
+   * @test
+   * @covers ::mul
+   */
+  public function assertMultiplyMethodProperlyMultipliesTwoNumbers ()
+  {
+    $expected = 4;
+    $actual = $this->calculator->mul("2", "2");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("float", $actual);
+  }
+
+  /**
+   * @test
+   * @covers ::div
+   */
+  public function assertDivideMethodProperlyDividesTwoNumbers ()
+  {
+    $expected = 2;
+    $actual = $this->calculator->div("4", "2");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("float", $actual);
+  }
+
+  /**
+   * @test
+   * @covers ::mod
+   */
+  public function assertModulusMethodProperlyReturnsTheRemainderOfDivision ()
+  {
+    $expected = 1;
+    $actual = $this->calculator->mod("5", "2");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("float", $actual);
+  }
+
+  /**
+   * @test
+   * @covers ::pow
+   */
+  public function assertPowerMethodRaisesBaseNumberToPowerExponent ()
+  {
+    $expected = 100;
+    $actual = $this->calculator->pow("10", "2");
+
+    $this->assertEquals($expected, $actual);
+    $this->assertInternalType("float", $actual);
+  }
+}


### PR DESCRIPTION
Added a calculator interface along with an abstract calculator to facilitate a concrete calculator class.

Included by default are two calculators; `SimpleCalculator` and `BinaryCalculator`.

The `SimpleCalculator` uses the native PHP `round` function in conjunction with the basic mathematical operators (`+`, `-`, `*`, `/`, `%`), and the `pow` function for power.

The `BinaryCalculator` uses the `bcmath` library, thus adding a requirement for this component for the `bcmath` extension.

See #12 for original issue details.