### PR TITLE
Converter calc

### DIFF
--- a/dev/examples.php
+++ b/dev/examples.php
@@ -5,14 +5,13 @@ ini_set('display_errors', 1);
 
 require_once "vendor/autoload.php";
 
+use UnitConverter\Measure;
 use UnitConverter\UnitConverter;
+use UnitConverter\Calculator\SimpleCalculator;
 use UnitConverter\Registry\UnitRegistry;
 use UnitConverter\Unit\AbstractUnit;
-use UnitConverter\Measure;
-use UnitConverter\Unit\Length\{
-  Centimeter,
-  Inch
-};
+use UnitConverter\Unit\Length\Centimeter;
+use UnitConverter\Unit\Length\Inch;
 
 # Configuring a New Converter
 # ===========================
@@ -23,8 +22,9 @@ $units = array(
 );
 
 $registry = new UnitRegistry($units);
+$calculator = new SimpleCalculator;
 
-$converter = new UnitConverter($registry);
+$converter = new UnitConverter($registry, $calculator);
 
 # Registering Custom Units
 # ========================

--- a/src/UnitConverter/Calculator/SimpleCalculator.php
+++ b/src/UnitConverter/Calculator/SimpleCalculator.php
@@ -66,42 +66,42 @@ class SimpleCalculator extends AbstractCalculator
    * @param int|float $value The value to round
    * @return float
    */
-  public function round ($value): float
+  public function round ($value, int $percision = null): float
   {
     return round(
       $value,
-      $this->getPrecision(),
+      ($percision ?? $this->getPrecision()),
       $this->getRoundingMode()
     );
   }
 
   public function add ($leftOperand, $rightOperand)
   {
-    return $this->round(($leftOperand + $rightOperand));
+    return ($leftOperand + $rightOperand);
   }
 
   public function sub ($leftOperand, $rightOperand)
   {
-    return $this->round(($leftOperand - $rightOperand));
+    return ($leftOperand - $rightOperand);
   }
 
   public function mul ($leftOperand, $rightOperand)
   {
-    return $this->round(($leftOperand * $rightOperand));
+    return ($leftOperand * $rightOperand);
   }
 
   public function div ($dividend, $divisor)
   {
-    return $this->round(($dividend / $divisor));
+    return ($dividend / $divisor);
   }
 
   public function mod ($dividend, $modulus)
   {
-    return $this->round(($dividend % $modulus));
+    return ($dividend % $modulus);
   }
 
   public function pow ($base, $exponent)
   {
-    return $this->round(pow($base, $exponent));
+    return pow($base, $exponent);
   }
 }

--- a/src/UnitConverter/Exception/MissingCalculatorException.php
+++ b/src/UnitConverter/Exception/MissingCalculatorException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the jordanbrauer/unit-converter PHP package.
+ *
+ * @copyright 2017 Jordan Brauer <jbrauer.inc@gmail.com>
+ * @license MIT
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace UnitConverter\Exception;
+
+use OutOfBoundsException;
+
+/**
+ * Exception thrown when the unit converter is missing a calculator
+ */
+class MissingCalculatorException extends OutOfBoundsException
+{
+}

--- a/src/UnitConverter/Unit/AbstractUnit.php
+++ b/src/UnitConverter/Unit/AbstractUnit.php
@@ -14,6 +14,8 @@ declare(strict_types = 1);
 
 namespace UnitConverter\Unit;
 
+use UnitConverter\Calculator\CalculatorInterface;
+
 /**
  * This class is the base class for all unit of measurement classes. When creating
  * a new/custom unit of measure, extend from this class. The Bare minimum
@@ -72,11 +74,13 @@ abstract class AbstractUnit implements UnitInterface
   /**
    * Calculate the amount of required base units to make up 1 unit.
    *
-   * @param float $value
+   * @param CalculatorInterface $calculator
+   * @param int|float|string $value
    * @param UnitInterface $to
-   * @return null|float
+   * @param int $percision The decimal percision to be calculated
+   * @return null|int|float|string
    */
-  protected function calculate (float $value, UnitInterface $to) : ?float
+  protected function calculate (CalculatorInterface $calculator, $value, UnitInterface $to, int $percision = null)
   {
     return null;
   }
@@ -84,13 +88,15 @@ abstract class AbstractUnit implements UnitInterface
   /**
    * Exposes access to the ::calculate() method.
    *
-   * @param float $value
+   * @param CalculatorInterface $calculator
+   * @param int|float|string $value
    * @param UnitInterface $to
-   * @return null|float
+   * @param int $percision The decimal percision to be calculated
+   * @return null|int|float|string
    */
-  public function convert (float $value, UnitInterface $to)
+  public function convert (CalculatorInterface $calculator, $value, UnitInterface $to, int $percision = null)
   {
-    return $this->calculate($value, $to);
+    return $this->calculate($calculator, $value, $to, $percision);
   }
 
   public function setName (string $name) : UnitInterface

--- a/src/UnitConverter/Unit/Temperature/Celsius.php
+++ b/src/UnitConverter/Unit/Temperature/Celsius.php
@@ -15,6 +15,7 @@ declare(strict_types = 1);
 namespace UnitConverter\Unit\Temperature;
 
 use Exception;
+use UnitConverter\Calculator\CalculatorInterface;
 use UnitConverter\Unit\UnitInterface;
 
 /**
@@ -35,18 +36,27 @@ class Celsius extends TemperatureUnit
       ;
   }
 
-  protected function calculate (float $value, UnitInterface $to) : ?float
+  protected function calculate (CalculatorInterface $calculator, $value, UnitInterface $to, int $percision = null)
   {
     $val = $value ?? $this->getBasetUnits();
 
     # 0 °K = 273.15 °C
     switch ($to->getSymbol()) {
       case 'f': # °F = (°C × (9 ÷ 5)) + 32
-        return ($val * (9 / 5)) + 32;
+        return $calculator->round(
+          $calculator->add(
+            $calculator->mul($val, $calculator->div(9, 5)),
+            32
+          ),
+          $percision
+        );
         break;
 
       case 'k': # °K = °C + 273.15
-        return ($val + 273.15);
+        return $calculator->round(
+          $calculator->add($val, 273.15),
+          $percision
+        );
         break;
 
       case 'c': # °C = °C

--- a/src/UnitConverter/Unit/Temperature/Fahrenheit.php
+++ b/src/UnitConverter/Unit/Temperature/Fahrenheit.php
@@ -15,6 +15,7 @@ declare(strict_types = 1);
 namespace UnitConverter\Unit\Temperature;
 
 use Exception;
+use UnitConverter\Calculator\CalculatorInterface;
 use UnitConverter\Unit\UnitInterface;
 
 /**
@@ -35,18 +36,30 @@ class Fahrenheit extends TemperatureUnit
       ;
   }
 
-  protected function calculate (float $value, UnitInterface $to) : ?float
+  protected function calculate (CalculatorInterface $calculator, $value, UnitInterface $to, int $percision = null)
   {
     $val = $value ?? $this->getBase()->getUnits();
 
     # 0 °K = 255.372 °F
     switch ($to->getSymbol()) {
       case 'c': # °C = (°F - 32) × (5 ÷ 9)
-        return ($val - 32) * (5 / 9);
+        return $calculator->round(
+          $calculator->mul(
+            $calculator->sub($val, 32),
+            $calculator->div(5, 9)
+          ),
+          $percision
+        );
         break;
 
       case 'k': # °K = (°F + 459.67) × (5 ÷ 9)
-        return (($val + 459.67) * 5 / 9);
+        return $calculator->round(
+          $calculator->mul(
+            $calculator->add($val, 459.67),
+            $calculator->div(5, 9)
+          ),
+          $percision
+        );
         break;
 
       case 'f': # °F = °F

--- a/src/UnitConverter/UnitConverter.php
+++ b/src/UnitConverter/UnitConverter.php
@@ -14,9 +14,11 @@ declare(strict_types = 1);
 
 namespace UnitConverter;
 
+use UnitConverter\Calculator\CalculatorInterface;
 use UnitConverter\Exception\MissingUnitRegistryException;
-use UnitConverter\Unit\UnitInterface;
+use UnitConverter\Exception\MissingCalculatorException;
 use UnitConverter\Registry\UnitRegistryInterface;
+use UnitConverter\Unit\UnitInterface;
 
 /**
  * The actual unit converter object.
@@ -28,9 +30,14 @@ use UnitConverter\Registry\UnitRegistryInterface;
 class UnitConverter implements UnitConverterInterface
 {
   /**
-   * @var UnitRegistryInterface The registry that the unit converter accesses available units from.
+   * @var UnitRegistryInterface $registry The registry that the unit converter accesses available units from
    */
   protected $registry;
+
+  /**
+   * @var CalculatorInterface $calculator The converters internal calculator used to handle mathematical operations
+   */
+  protected $calculator;
 
   /**
    * @var float $convert The value being converted.
@@ -48,77 +55,25 @@ class UnitConverter implements UnitConverterInterface
   protected $to;
 
   /**
+   * @var int $percision The decimal precision to be calculated
+   */
+  protected $percision;
+
+  /**
    * Public constructor function for the UnitConverter class.
    *
    * @param UnitInterface[] $registry A two-dimensional array of UnitInterface objects.
    * @return self
    */
-  public function __construct (UnitRegistryInterface $registry = null)
+  public function __construct (UnitRegistryInterface $registry, CalculatorInterface $calculator)
   {
     $this->setRegistry($registry);
+    $this->setCalculator($calculator);
   }
 
-  /**
-   * Determine whether or not the converter has an active registry.
-   *
-   * @internal
-   * @return bool
-   */
-  protected function registryExists () : bool
+  public function convert ($value, int $percision = null)
   {
-    if ($this->registry instanceof UnitRegistryInterface)
-      return true;
-
-    return false;
-  }
-
-  /**
-   * Load a unit from the unit converter registry.
-   *
-   * @internal
-   * @uses UnitConverter\UnitRegistry::loadUnit
-   * @throws MissingUnitRegistryException An out of bounds exception will be thrown if an attempt is made to access a non-existent registry.
-   * @return UnitInterface
-   */
-  protected function loadUnit(string $symbol) : UnitInterface
-  {
-    if ($this->registryExists() === false)
-      throw new MissingUnitRegistryException("No unit registry was found to load units from.");
-
-    return $this->registry->loadUnit($symbol);
-  }
-
-  /**
-   * Calculate the conversion from one unit to another.
-   *
-   * @FIXME Gross use of a check for a null calculate() method ... 😑 Gotta
-   * figure out a better way to use the calulate method.
-   *
-   * @internal
-   * @param float $value The initial value being converted.
-   * @param UnitInterface $from The unit of measure being converted **from**.
-   * @param UnitInterface $to The unit of measure being converted **to**.
-   * @return float
-   */
-  protected function calculate (float $value, UnitInterface $from, UnitInterface $to): float
-  {
-    $selfConversion = $from->convert($value, $to);
-
-    if ($selfConversion)
-      return $selfConversion;
-
-    # If the unit does not implement the calculate() method, convert it manually.
-    return ($value * $from->getUnits()) / $to->getUnits();
-  }
-
-  public function setRegistry ($registry) : UnitConverterInterface
-  {
-    $this->registry = $registry;
-    return $this;
-  }
-
-  public function convert (float $value)
-  {
+    $this->percision = $percision;
     $this->convert = $value;
     return $this;
   }
@@ -132,6 +87,120 @@ class UnitConverter implements UnitConverterInterface
   public function to (string $unit)
   {
     $this->to = $this->loadUnit($unit);
-    return $this->calculate($this->convert, $this->from, $this->to);
+    return $this->calculate(
+      $this->calculator,
+      $this->convert,
+      $this->from,
+      $this->to,
+      $this->percision
+    );
+  }
+
+  /**
+   * Calculate the conversion from one unit to another.
+   *
+   * @FIXME Gross use of a check for a null calculate() method ... 😑 Gotta
+   * figure out a better way to use the calulate method.
+   *
+   * @internal
+   * @throws MissingCalculatorException
+   * @param CalculatorInterface $calculator $The calculator being used to
+   * @param int|float|string $value The initial value being converted.
+   * @param UnitInterface $from The unit of measure being converted **from**.
+   * @param UnitInterface $to The unit of measure being converted **to**.
+   * @param int $percision The decimal percision to be calculated
+   * @return int|float|string
+   */
+  protected function calculate (
+    CalculatorInterface $calculator,
+    $value,
+    UnitInterface $from,
+    UnitInterface $to,
+    int $percision = null
+  ) {
+    $selfConversion = $from->convert($calculator, $value, $to, $percision);
+
+    if ($selfConversion)
+      return $selfConversion;
+
+    if ($this->calculatorExists() === false)
+      throw new MissingCalculatorException("No calculator was found to perform mathematical operations with.");
+
+    # If the unit does not implement the calculate() method, convert it manually.
+    return $calculator->round(
+      $calculator->div(
+        $calculator->mul($value, $from->getUnits()),
+        $to->getUnits()
+      ),
+      $percision
+    );
+  }
+
+  /**
+   * Load a unit from the unit converter registry.
+   *
+   * @internal
+   * @uses UnitConverter\UnitRegistry::loadUnit
+   * @throws MissingUnitRegistryException An out of bounds exception will be thrown if an attempt is made to access a non-existent registry.
+   * @return UnitInterface
+   */
+  protected function loadUnit(string $symbol): UnitInterface
+  {
+    if ($this->registryExists() === false)
+      throw new MissingUnitRegistryException("No unit registry was found to load units from.");
+
+    return $this->registry->loadUnit($symbol);
+  }
+
+  /**
+   * Set the unit converter registry for storing units of measure to convert values with.
+   *
+   * @api
+   * @param UnitRegistryInterface $registry An instance of UnitRegistry.
+   */
+  public function setRegistry (UnitRegistryInterface $registry): UnitConverterInterface
+  {
+    $this->registry = $registry;
+    return $this;
+  }
+
+  /**
+   * Set the unit converter calculator to perform mathematical operations with.
+   *
+   * @api
+   * @param CalculatorInterface $calculator An instance of a CalculatorInterface
+   */
+  public function setCalculator (CalculatorInterface $calculator): UnitConverterInterface
+  {
+    $this->calculator = $calculator;
+    return $this;
+  }
+
+  /**
+   * Determine whether or not the converter has an active registry.
+   *
+   * @internal
+   * @return bool
+   */
+  protected function registryExists (): bool
+  {
+    if ($this->registry instanceof UnitRegistryInterface)
+      return true;
+
+    return false;
+  }
+
+  /**
+   * Determine whether or not the converter has an active calculator.
+   *
+   * @internal
+   * @return bool
+   */
+  protected function calculatorExists (): bool
+  {
+    if ($this->calculator instanceof CalculatorInterface)
+      return true;
+
+    return false;
   }
 }

--- a/src/UnitConverter/UnitConverterInterface.php
+++ b/src/UnitConverter/UnitConverterInterface.php
@@ -28,22 +28,15 @@ use UnitConverter\Unit\UnitInterface;
 interface UnitConverterInterface
 {
   /**
-   * Set the unit converter registry for storing units of measure to convert values with.
-   *
-   * @api
-   * @param UnitRegistryInterface $registry An instance of UnitRegistry.
-   */
-  public function setRegistry ($registry) : UnitConverterInterface;
-
-  /**
    * Set the unit converters' value to be converted. This method is the first
    * method to be called in the chain of conversion methods.
    *
    * @api
    * @example $converter->convert(1)->from("in")->to("cm");
-   * @param float $value The numerical value being converted.
+   * @param int|float|string $value The numerical value being converted.
+   * @param int $precision The decimal precision to be rounded to
    */
-  public function convert (float $value);
+  public function convert ($value, int $percision = null);
 
   /**
    * Set the unit converters' unit to be converted **from**. This method is the

--- a/tests/integration/UnitConverter/Unit/Energy/EnergyUnits.spec.php
+++ b/tests/integration/UnitConverter/Unit/Energy/EnergyUnits.spec.php
@@ -16,11 +16,10 @@ namespace UnitConverter\Tests\Integration\Unit\Energy;
 
 use PHPUnit\Framework\TestCase;
 use UnitConverter\UnitConverter;
+use UnitConverter\Calculator\SimpleCalculator;
 use UnitConverter\Registry\UnitRegistry;
-use UnitConverter\Unit\Energy\{
-  Joule,
-  Calorie
-};
+use UnitConverter\Unit\Energy\Joule;
+use UnitConverter\Unit\Energy\Calorie;
 
 /**
  * Test the default volume units for conversion accuracy.
@@ -35,7 +34,8 @@ class EnergyUnitsSpec extends TestCase
       new UnitRegistry(array(
         new Joule,
         new Calorie,
-      ))
+      )),
+      new SimpleCalculator
     );
   }
 
@@ -48,15 +48,15 @@ class EnergyUnitsSpec extends TestCase
    * @test
    * @coversNothing
    */
-  public function assert ()
+  public function assert1CalorieEquals4184Joules ()
   {
-    $expected = 50208;
+    $expected = 4184;
     $actual = $this->converter
-      ->convert(12)
+      ->convert(1)
       ->from("cal")
       ->to("J")
       ;
 
-    $this->assertEquals(round($expected, 3), round($actual, 3));
+    $this->assertEquals($expected, $actual);
   }
 }

--- a/tests/integration/UnitConverter/Unit/Pressure/PressureUnits.spec.php
+++ b/tests/integration/UnitConverter/Unit/Pressure/PressureUnits.spec.php
@@ -16,12 +16,11 @@ namespace UnitConverter\Tests\Integration\Unit\Pressure;
 
 use PHPUnit\Framework\TestCase;
 use UnitConverter\UnitConverter;
+use UnitConverter\Calculator\SimpleCalculator;
 use UnitConverter\Registry\UnitRegistry;
-use UnitConverter\Unit\Pressure\{
-  Pascal,
-  Kilopascal,
-  PoundForcePerSquareInch as PSI
-};
+use UnitConverter\Unit\Pressure\Pascal;
+use UnitConverter\Unit\Pressure\Kilopascal;
+use UnitConverter\Unit\Pressure\PoundForcePerSquareInch as PSI;
 
 /**
  * Test the default pressure units for conversion accuracy.
@@ -37,7 +36,8 @@ class PressureUnitsSpec extends TestCase
         new Pascal,
         new Kilopascal,
         new PSI,
-      ))
+      )),
+      new SimpleCalculator
     );
   }
 
@@ -59,7 +59,7 @@ class PressureUnitsSpec extends TestCase
       ->to("pa")
       ;
 
-    $this->assertEquals(round($expected, 2), round($actual, 2));
+    $this->assertEquals($expected, $actual);
   }
 
     /**
@@ -75,7 +75,7 @@ class PressureUnitsSpec extends TestCase
             ->to("pa")
         ;
 
-        $this->assertEquals(round($expected, 2), round($actual, 2));
+        $this->assertEquals($expected, $actual);
     }
 
     /**
@@ -91,7 +91,7 @@ class PressureUnitsSpec extends TestCase
             ->to("kpa")
         ;
 
-        $this->assertEquals(round($expected, 2), round($actual, 2));
+        $this->assertEquals($expected, $actual);
     }
 
     /**
@@ -106,7 +106,7 @@ class PressureUnitsSpec extends TestCase
             ->to("pa")
         ;
 
-        $this->assertEquals(round($expected, 2), round($actual, 2));
+        $this->assertEquals($expected, $actual);
     }
 
     /**
@@ -121,6 +121,6 @@ class PressureUnitsSpec extends TestCase
             ->to("kpa")
         ;
 
-        $this->assertEquals(round($expected, 2), round($actual, 2));
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/integration/UnitConverter/Unit/Temperature/TemperatureUnits.spec.php
+++ b/tests/integration/UnitConverter/Unit/Temperature/TemperatureUnits.spec.php
@@ -16,12 +16,11 @@ namespace UnitConverter\Tests\Integration\Unit\Temperature;
 
 use PHPUnit\Framework\TestCase;
 use UnitConverter\UnitConverter;
+use UnitConverter\Calculator\SimpleCalculator;
 use UnitConverter\Registry\UnitRegistry;
-use UnitConverter\Unit\Temperature\{
-  Celsius,
-  Fahrenheit,
-  Kelvin
-};
+use UnitConverter\Unit\Temperature\Celsius;
+use UnitConverter\Unit\Temperature\Fahrenheit;
+use UnitConverter\Unit\Temperature\Kelvin;
 
 /**
  * Test the default temperature units for conversion accuracy.
@@ -37,7 +36,8 @@ class TemperatureUnitsSpec extends TestCase
         new Celsius,
         new Fahrenheit,
         new Kelvin,
-      ))
+      )),
+      new SimpleCalculator
     );
   }
 
@@ -59,7 +59,7 @@ class TemperatureUnitsSpec extends TestCase
       ->to("k")
       ;
 
-    $this->assertEquals(round($expected, 2), round($actual, 2));
+    $this->assertEquals($expected, $actual);
   }
 
   /**
@@ -75,7 +75,7 @@ class TemperatureUnitsSpec extends TestCase
       ->to("k")
       ;
 
-    $this->assertEquals(round($expected, 2), round($actual, 2));
+    $this->assertEquals($expected, $actual);
   }
 
   /**
@@ -91,7 +91,7 @@ class TemperatureUnitsSpec extends TestCase
       ->to("f")
       ;
 
-    $this->assertEquals(round($expected, 2), round($actual, 2));
+    $this->assertEquals($expected, $actual);
   }
 
   /**
@@ -102,11 +102,11 @@ class TemperatureUnitsSpec extends TestCase
   {
     $expected = -17.7778;
     $actual = $this->converter
-      ->convert(0)
+      ->convert(0, 4)
       ->from("f")
       ->to("c")
       ;
 
-    $this->assertEquals(round($expected, 2), round($actual, 2));
+    $this->assertEquals($expected, $actual);
   }
 }

--- a/tests/integration/UnitConverter/Unit/Volume/VolumeUnits.spec.php
+++ b/tests/integration/UnitConverter/Unit/Volume/VolumeUnits.spec.php
@@ -16,13 +16,12 @@ namespace UnitConverter\Tests\Integration\Unit\Volume;
 
 use PHPUnit\Framework\TestCase;
 use UnitConverter\UnitConverter;
+use UnitConverter\Calculator\SimpleCalculator;
 use UnitConverter\Registry\UnitRegistry;
-use UnitConverter\Unit\Volume\{
-  Litre,
-  Mililitre,
-  Gallon,
-  Pint
-};
+use UnitConverter\Unit\Volume\Litre;
+use UnitConverter\Unit\Volume\Mililitre;
+use UnitConverter\Unit\Volume\Gallon;
+use UnitConverter\Unit\Volume\Pint;
 
 /**
  * Test the default volume units for conversion accuracy.
@@ -39,7 +38,8 @@ class VolumeUnitsSpec extends TestCase
         new Mililitre,
         new Gallon,
         new Pint,
-      ))
+      )),
+      new SimpleCalculator
     );
   }
 
@@ -56,11 +56,11 @@ class VolumeUnitsSpec extends TestCase
   {
     $expected = 4.73176;
     $actual = $this->converter
-      ->convert(10)
+      ->convert(10, 5)
       ->from("pt")
       ->to("l")
       ;
 
-    $this->assertEquals(round($expected, 5), round($actual, 5));
+    $this->assertEquals($expected, $actual);
   }
 }

--- a/tests/unit/UnitConverter/Calculator/SimpleCalculator.spec.php
+++ b/tests/unit/UnitConverter/Calculator/SimpleCalculator.spec.php
@@ -69,7 +69,7 @@ class SimpleCalculatorSpec extends TestCase
     $actual = $this->calculator->mul("2", "2");
 
     $this->assertEquals($expected, $actual);
-    $this->assertInternalType("float", $actual);
+    $this->assertInternalType("int", $actual);
   }
 
   /**
@@ -82,7 +82,7 @@ class SimpleCalculatorSpec extends TestCase
     $actual = $this->calculator->div("4", "2");
 
     $this->assertEquals($expected, $actual);
-    $this->assertInternalType("float", $actual);
+    $this->assertInternalType("int", $actual);
   }
 
   /**
@@ -95,7 +95,7 @@ class SimpleCalculatorSpec extends TestCase
     $actual = $this->calculator->mod("5", "2");
 
     $this->assertEquals($expected, $actual);
-    $this->assertInternalType("float", $actual);
+    $this->assertInternalType("int", $actual);
   }
 
   /**
@@ -108,6 +108,6 @@ class SimpleCalculatorSpec extends TestCase
     $actual = $this->calculator->pow("10", "2");
 
     $this->assertEquals($expected, $actual);
-    $this->assertInternalType("float", $actual);
+    $this->assertInternalType("int", $actual);
   }
 }

--- a/tests/unit/UnitConverter/UnitConverter.spec.php
+++ b/tests/unit/UnitConverter/UnitConverter.spec.php
@@ -16,6 +16,7 @@ namespace UnitConverter\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use UnitConverter\UnitConverter;
+use UnitConverter\Calculator\SimpleCalculator;
 use UnitConverter\Registry\UnitRegistry;
 use UnitConverter\Unit\Length\{
   Centimeter,
@@ -34,24 +35,14 @@ class UnitConverterSpec extends TestCase
       new UnitRegistry(array(
         new Centimeter,
         new Inch,
-      ))
+      )),
+      new SimpleCalculator
     );
   }
 
   protected function tearDown ()
   {
     unset($this->converter);
-  }
-
-  /**
-   * @test
-   * @coversNothing
-   */
-  public function assertConversionAttemptsWithoutARegistryThrowsOutOfBoundsException ()
-  {
-    $this->expectException("UnitConverter\\Exception\\MissingUnitRegistryException");
-    $converter = new UnitConverter;
-    $converter->convert(1)->from("in")->to("cm");
   }
 
   /**


### PR DESCRIPTION
Closes #12 

The `BinaryCalculator` (`bcmath`) won't work quite yet, as it require it's arguments to be strings. To do this, I imagine we can cast our hard-coded parameters to strings if the currently active calculator is the `BinaryCalculator`