### PR TITLE
Fix regression bug #139

### DIFF
--- a/src/UnitConverter/Unit/AbstractUnit.php
+++ b/src/UnitConverter/Unit/AbstractUnit.php
@@ -108,7 +108,7 @@ abstract class AbstractUnit implements UnitInterface
     {
         return \UnitConverter\UnitConverter::createBuilder()
             ->{'add'.(($binary) ? 'Binary' : 'Simple').'Calculator'}() # ¯\_(ツ)_/¯
-            ->addRegistryWith([$this, $unit])
+            ->addRegistryWith(array_unique([$this, $unit], SORT_REGULAR))
             ->build()
             // ->disableConversionLog() # TODO: when this returns interface, uncomment!
             ->convert((string) $this->getValue(), $precision)

--- a/tests/unit/UnitConverter/Unit/AbstractUnit.spec.php
+++ b/tests/unit/UnitConverter/Unit/AbstractUnit.spec.php
@@ -90,6 +90,16 @@ class AbstractUnitSpec extends TestCase
 
     /**
      * @test
+     * @covers ::as
+     * @return void
+     */
+    public function assertAsUnitConversationWorkForSameUnits()
+    {
+        $this->assertEquals(1, (new Inch(1))->as(new Inch()));
+    }
+
+    /**
+     * @test
      * @covers ::getBaseUnits
      * @return void
      */


### PR DESCRIPTION
See issue #127 for original bug.

See pull request #132 for offending changes.

### Summary

use array unique regular sort to do make units "smart" and not add itself twice to the registry for usage with `as` method.