### PR TITLE
fix #160 add type checks to calculator inputs

### DIFF
--- a/src/Calculator/AbstractCalculator.php
+++ b/src/Calculator/AbstractCalculator.php
@@ -14,6 +14,8 @@ declare(strict_types = 1);
 
 namespace UnitConverter\Calculator;
 
+use Closure;
+use TypeError;
 use UnitConverter\Calculator\Formula\FormulaInterface;
 
 /**
@@ -68,6 +70,12 @@ abstract class AbstractCalculator implements CalculatorInterface
      * @const int ROUND_HALF_UP
      */
     const ROUND_HALF_UP = PHP_ROUND_HALF_UP;
+
+    /**
+     * String value representation of the allowed scalar type(s) for the
+     * calculator's inputs.
+     */
+    protected const SCALAR = 'int|float|string';
 
     /**
      * A non-persitent stack of events for the current calculator's calculations
@@ -276,6 +284,36 @@ abstract class AbstractCalculator implements CalculatorInterface
     public function subtract(...$params)
     {
         return $this->sub(...$params);
+    }
+
+    /**
+     * Throw a type error if the given closure does not evaluate to true for one
+     * of given values. The name of the method and allowed type string are used
+     * to create an error message.
+     *
+     * @param Closure $assert Type check that must return true, otherwise an error is thrown
+     * @param string $method The name of the method that is calling this method, used for error message
+     * @param string $allowed The allowed type of the value, used for error message
+     * @param mixed ...$value One or more values to test with the given closure
+     * @return void
+     * @throws TypeError When the given closure does not return true
+     */
+    protected static function invariant(Closure $assert, string $method, string $allowed, ...$value): void
+    {
+        foreach ($value as $position => $arg) {
+            if ($assert($arg)) {
+                continue;
+            }
+
+            throw new TypeError(sprintf(
+                'Argument %d passed to %s::%s must be of the type %s, %s given',
+                1 + $position,
+                static::class,
+                $method,
+                $allowed,
+                gettype($arg),
+            ));
+        }
     }
 
     /**

--- a/src/Calculator/AbstractCalculator.php
+++ b/src/Calculator/AbstractCalculator.php
@@ -243,6 +243,15 @@ abstract class AbstractCalculator implements CalculatorInterface
      */
     public function round($value, int $precision = null)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand);
+            },
+            __FUNCTION__,
+            static::SCALAR,
+            $value,
+        );
+
         return round(
             $value,
             ($precision ?? $this->getPrecision()),

--- a/src/Calculator/BinaryCalculator.php
+++ b/src/Calculator/BinaryCalculator.php
@@ -14,6 +14,8 @@ declare(strict_types = 1);
 
 namespace UnitConverter\Calculator;
 
+use RuntimeException;
+
 /**
  * A concrete calculator calss that uses the bcmath library
  * to perform mathematical operations.
@@ -27,6 +29,25 @@ namespace UnitConverter\Calculator;
  */
 class BinaryCalculator extends AbstractCalculator
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(int $precision = null, int $roundingMode = null)
+    {
+        if (extension_loaded('bcmath')) {
+            parent::__construct($precision, $roundingMode);
+
+            return;
+        }
+
+        $fqcn = explode('\\', static::class);
+
+        throw new RuntimeException(sprintf(
+            'Unable to construct a %s due to missing bcmath library. Please check your PHP extensions.',
+            end($fqcn),
+        ));
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/Calculator/BinaryCalculator.php
+++ b/src/Calculator/BinaryCalculator.php
@@ -32,6 +32,11 @@ class BinaryCalculator extends AbstractCalculator
     /**
      * {@inheritDoc}
      */
+    protected const SCALAR = 'string';
+
+    /**
+     * {@inheritDoc}
+     */
     public function __construct(int $precision = null, int $roundingMode = null)
     {
         if (extension_loaded('bcmath')) {
@@ -53,6 +58,15 @@ class BinaryCalculator extends AbstractCalculator
      */
     public function add($leftOperand, $rightOperand)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand) and is_string($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            ...func_get_args(), // IDEA: make method arguments variadic instead
+        );
+
         return bcadd($leftOperand, $rightOperand);
     }
 
@@ -61,6 +75,16 @@ class BinaryCalculator extends AbstractCalculator
      */
     public function div($dividend, $divisor)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand) and is_string($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            $dividend,
+            $divisor,
+        );
+
         return bcdiv($dividend, $divisor);
     }
 
@@ -69,6 +93,16 @@ class BinaryCalculator extends AbstractCalculator
      */
     public function mod($dividend, $modulus)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand) and is_string($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            $dividend,
+            $modulus,
+        );
+
         return bcmod($dividend, $modulus);
     }
 
@@ -77,6 +111,15 @@ class BinaryCalculator extends AbstractCalculator
      */
     public function mul($leftOperand, $rightOperand)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand) and is_string($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            ...func_get_args(), // IDEA: make method arguments variadic instead
+        );
+
         return bcmul($leftOperand, $rightOperand);
     }
 
@@ -85,6 +128,16 @@ class BinaryCalculator extends AbstractCalculator
      */
     public function pow($base, $exponent)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand) and is_string($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            $base,
+            $exponent,
+        );
+
         return bcpow($base, $exponent);
     }
 
@@ -119,6 +172,15 @@ class BinaryCalculator extends AbstractCalculator
      */
     public function sub($leftOperand, $rightOperand)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand) and is_string($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            ...func_get_args(), // IDEA: make method arguments variadic instead
+        );
+
         return bcsub($leftOperand, $rightOperand);
     }
 }

--- a/src/Calculator/SimpleCalculator.php
+++ b/src/Calculator/SimpleCalculator.php
@@ -35,6 +35,15 @@ class SimpleCalculator extends AbstractCalculator
      */
     public function add($leftOperand, $rightOperand)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            ...func_get_args(), // IDEA: make method arguments variadic instead
+        );
+
         return $leftOperand + $rightOperand;
     }
 
@@ -43,6 +52,16 @@ class SimpleCalculator extends AbstractCalculator
      */
     public function div($dividend, $divisor)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            $dividend,
+            $divisor,
+        );
+
         return $dividend / $divisor;
     }
 
@@ -51,6 +70,16 @@ class SimpleCalculator extends AbstractCalculator
      */
     public function mod($dividend, $modulus)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            $dividend,
+            $modulus,
+        );
+
         return $dividend % $modulus;
     }
 
@@ -59,6 +88,15 @@ class SimpleCalculator extends AbstractCalculator
      */
     public function mul($leftOperand, $rightOperand)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            ...func_get_args(), // IDEA: make method arguments variadic instead
+        );
+
         return $leftOperand * $rightOperand;
     }
 
@@ -67,6 +105,16 @@ class SimpleCalculator extends AbstractCalculator
      */
     public function pow($base, $exponent)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            $base,
+            $exponent,
+        );
+
         return pow($base, $exponent);
     }
 
@@ -75,6 +123,15 @@ class SimpleCalculator extends AbstractCalculator
      */
     public function sub($leftOperand, $rightOperand)
     {
+        self::invariant(
+            static function ($operand): bool {
+                return is_numeric($operand);
+            },
+            __FUNCTION__,
+            self::SCALAR,
+            ...func_get_args(), // IDEA: make method arguments variadic instead
+        );
+
         return $leftOperand - $rightOperand;
     }
 }

--- a/tests/unit/Calculator/BinaryCalculator.spec.php
+++ b/tests/unit/Calculator/BinaryCalculator.spec.php
@@ -16,6 +16,7 @@ namespace UnitConverter\Tests\Unit\Calculator;
 
 use PHPUnit\Framework\TestCase;
 use UnitConverter\Calculator\BinaryCalculator;
+use TypeError;
 
 /**
  * @coversDefaultClass UnitConverter\Calculator\BinaryCalculator
@@ -136,5 +137,75 @@ class BinaryCalculatorSpec extends TestCase
         $this->assertEquals($expected, $actual);
         // $this->assertSame($expected, $actual); # TODO: figure rounding issues – #54
         $this->assertInternalType("string", $actual);
+    }
+
+    /**
+     * @test
+     * @covers ::add
+     */
+    public function assertErrorIsThrownForInvalidAdditionTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->add('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::sub
+     */
+    public function assertErrorIsThrownForInvalidSubtractionTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->sub('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::mul
+     */
+    public function assertErrorIsThrownForInvalidMultiplicationTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->mul('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::div
+     */
+    public function assertErrorIsThrownForInvalidDivisionTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->div('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::mod
+     */
+    public function assertErrorIsThrownForInvalidModulusTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->mod('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::pow
+     */
+    public function assertErrorIsThrownForInvalidPowerTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->pow('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::round
+     */
+    public function assertErrorIsThrownForInvalidRoundingTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->round('asdf.34');
     }
 }

--- a/tests/unit/Calculator/SimpleCalculator.spec.php
+++ b/tests/unit/Calculator/SimpleCalculator.spec.php
@@ -15,6 +15,7 @@ declare(strict_types = 1);
 namespace UnitConverter\Tests\Unit\Calculator;
 
 use PHPUnit\Framework\TestCase;
+use TypeError;
 use UnitConverter\Calculator\SimpleCalculator;
 
 /**
@@ -110,5 +111,75 @@ class SimpleCalculatorSpec extends TestCase
 
         $this->assertEquals($expected, $actual);
         $this->assertInternalType("float", $actual);
+    }
+
+    /**
+     * @test
+     * @covers ::add
+     */
+    public function assertErrorIsThrownForInvalidAdditionTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->add('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::sub
+     */
+    public function assertErrorIsThrownForInvalidSubtractionTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->sub('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::mul
+     */
+    public function assertErrorIsThrownForInvalidMultiplicationTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->mul('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::div
+     */
+    public function assertErrorIsThrownForInvalidDivisionTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->div('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::mod
+     */
+    public function assertErrorIsThrownForInvalidModulusTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->mod('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::pow
+     */
+    public function assertErrorIsThrownForInvalidPowerTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->pow('asdf', 'asdf');
+    }
+
+    /**
+     * @test
+     * @covers ::round
+     */
+    public function assertErrorIsThrownForInvalidRoundingTypeInput()
+    {
+        $this->expectException(TypeError::class);
+        $this->calculator->round('asdf.34');
     }
 }


### PR DESCRIPTION
- throw `RuntimeException`s when the bcmath extension is missing upon attempting to instantiate a `BinaryCalculator`
  - this could happen if someone were to install the package while ignoring platform requirements
- throw `TypeError`s upon receiving invalid numeric input for `SimpleCalculator` and `BinaryCalculator`
- add unit tests for both the `SimpleCalculator` and the `BinaryCalculator` to ensure errors are thrown

closes #160 