### PR TITLE
Fix #120

### DIFF
--- a/src/Measure.php
+++ b/src/Measure.php
@@ -133,6 +133,8 @@ class Measure
 
     const FREQUENCY = 'frequency';
 
+    const FUEL_ECONOMY = 'fuel_economy';
+
     const LENGTH = "length";
 
     const MASS = "mass";
@@ -190,9 +192,6 @@ class Measure
             Litre::class,
             Millilitre::class,
             Pint::class,
-            KilometrePerLitre::class,
-            LitrePer100Kilometres::class,
-            MilesPerGallon::class,
         ],
         self::MASS => [
             Gram::class,
@@ -278,6 +277,11 @@ class Measure
             Megabyte::class,
             Gigabyte::class,
             Terabyte::class,
+        ],
+        self::FUEL_ECONOMY => [
+            KilometrePerLitre::class,
+            LitrePer100Kilometres::class,
+            MilesPerGallon::class,
         ],
     ];
 

--- a/src/Unit/FuelEconomy/FuelEconomyUnit.php
+++ b/src/Unit/FuelEconomy/FuelEconomyUnit.php
@@ -29,5 +29,5 @@ abstract class FuelEconomyUnit extends AbstractUnit
 {
     protected $base = KilometrePerLitre::class;
 
-    protected $unitOf = Measure::VOLUME;
+    protected $unitOf = Measure::FUEL_ECONOMY;
 }

--- a/tests/unit/Registry/UnitRegistry.spec.php
+++ b/tests/unit/Registry/UnitRegistry.spec.php
@@ -83,6 +83,7 @@ class UnitRegistrySpec extends TestCase
             "energy",
             "frequency",
             "digital_storage",
+            "fuel_economy",
         ];
 
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
fixes division by zero when converting all (default) units of volume

see #120 