### PR TITLE
fix: TypeError when converting units from one family to another (#177)

### DIFF
--- a/src/Exception/BadUnit.php
+++ b/src/Exception/BadUnit.php
@@ -15,6 +15,7 @@ declare(strict_types = 1);
 namespace UnitConverter\Exception;
 
 use Exception;
+use UnitConverter\Unit\UnitInterface;
 
 /**
  * Exception to be thrown when a bad unit of measurement is encountered.
@@ -25,9 +26,29 @@ use Exception;
  */
 final class BadUnit extends Exception
 {
+    const ERROR_CONVERTING = 4;
+
     const ERROR_SCALAR_TYPE = 2;
 
     const ERROR_SELF_CONVERSION_FORMULA = 3;
+
+    /**
+     * Throw a new exception for a bad unit conversion attempt.
+     */
+    public static function conversion(UnitInterface $from, UnitInterface $to, Exception $previous = null): Exception
+    {
+        return new self(
+            sprintf(
+                "Unable to convert from %s (%s) to %s (%s)",
+                $from->getUnitOf(),
+                $from->getScientificSymbol(),
+                $to->getUnitOf(),
+                $to->getScientificSymbol()
+            ),
+            self::ERROR_CONVERTING,
+            $previous
+        );
+    }
 
     /**
      * Throw a new exception for an un unkown self conversioin unit formula.

--- a/src/UnitConverter.php
+++ b/src/UnitConverter.php
@@ -19,6 +19,7 @@ use UnitConverter\Calculator\BinaryCalculator;
 use UnitConverter\Calculator\CalculatorInterface;
 use UnitConverter\Calculator\Formula\UnitConversionFormula;
 use UnitConverter\Exception\BadConverter;
+use UnitConverter\Exception\BadUnit;
 use UnitConverter\Registry\UnitRegistryInterface;
 use UnitConverter\Unit\UnitInterface;
 
@@ -357,6 +358,10 @@ class UnitConverter implements UnitConverterInterface
     {
         if (!$this->calculatorExists()) {
             throw BadConverter::missingCalculator();
+        }
+
+        if ($this->from->getUnitOf() !== $this->to->getUnitOf()) {
+            throw BadUnit::conversion($this->from, $this->to);
         }
 
         if ($this->conversionExists()) {

--- a/tests/unit/UnitConverter.spec.php
+++ b/tests/unit/UnitConverter.spec.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use UnitConverter\Calculator\SimpleCalculator;
 use UnitConverter\ConverterBuilder;
 use UnitConverter\Exception\BadRegistry;
+use UnitConverter\Exception\BadUnit;
 use UnitConverter\Measure;
 use UnitConverter\Registry\UnitRegistry;
 use UnitConverter\UnitConverter;
@@ -95,6 +96,21 @@ class UnitConverterSpec extends TestCase
             'two point five four',
             $this->converter->convert(1)->from('in')->spellout('cm'),
         );
+    }
+
+    /**
+     * @test
+     * @covers UnitConverter\Exception\BadUnit
+     */
+    public function assertConversionThrowsForCrossMeasurements(): void
+    {
+        $this->expectException(BadUnit::class);
+        $this->expectExceptionCode(BadUnit::ERROR_CONVERTING);
+
+        UnitConverter::default()
+            ->convert(1)
+            ->from('cm')
+            ->to('F');
     }
 
     /**


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce? Check/place an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description

Throw a domain exception when a conversion from one unit of measure to another is attempted (e.g., centimetres to Fahrenheit – length to temperature).

## Motivation and Context

See #177.

## How Has This Been Tested?

Automated unit test.

## Screenshots:

_N/A_