### PR TITLE
fix: BinaryCalculator::product() rtrim usage (#174)

### DIFF
--- a/src/Calculator/BinaryCalculator.php
+++ b/src/Calculator/BinaryCalculator.php
@@ -112,7 +112,7 @@ class BinaryCalculator extends AbstractCalculator
      */
     private static function product(string $value): string
     {
-        return (false !== stristr($value, '.')) ? rtrim($value, '0.,') : $value;
+        return (false !== stristr($value, '.')) ? rtrim(rtrim($value, '0'), '.,') : $value;
     }
 
     /**


### PR DESCRIPTION
Fixes #174

## Types of changes

What types of changes does your code introduce? Check/place an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Description

Use of `rtrim($value, '0.,')`, causes any value of 0 to the left of the decimal (ones-place and greater) to be trimmed off due to the way rtrim repeats removal until the first non-matching character.

## Motivation and Context

Fix BinaryCalculator::product() rtrim usage (#174)

Details in my comment on the issue.

## How Has This Been Tested?

Locally by running tests:
```
php vendor/bin/pest --colors=always
```
